### PR TITLE
Document advantages and comparisons of pioarduino-vscode-ide fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@
 **Frameworks**: Arduino, ESP-IDF
 
 
+## Why use this fork?
+
+Wondering how this differs from the official PlatformIO IDE and why you might want to switch? 
+Read the full breakdown: [**pioarduino-vscode-ide vs. PlatformIO IDE: Understanding the Added Value**](WHY_THIS_FORK.md).
+
+
 ## How it works
 
 The installation of pioarduino is like PlatformIO IDE for VSCode. Search for `pioarduino` on the [Visual Studio Code Marketplace](https://marketplace.visualstudio.com/search?term=pioarduino&target=VSCode&category=All%20categories&sortBy=Relevance) and follow the documentation [PlatformIO IDE for VSCode](http://docs.platformio.org/page/ide/vscode.html) how to install.

--- a/WHY_THIS_FORK.md
+++ b/WHY_THIS_FORK.md
@@ -1,0 +1,23 @@
+# pioarduino-vscode-ide vs. PlatformIO IDE: Understanding the Added Value
+
+If you are considering switching your development environment, the most important thing to know upfront is this: **pioarduino-vscode-ide can do everything the original PlatformIO IDE does.** Becuse it is a direct fork of the original extension, it shares the exact same underlying engine and interface. If you develop for STM32, Atmel AVR, RP2040, or any other non-Espressif architecture, your workflow, compilation, and uploading will remain 100% identical and fully supported. 
+
+Here is a breakdown of where the two diverge and the specific added value the `pioarduino` fork brings to the table.
+
+## Can't I just use standard PlatformIO?
+
+Yes. It is entirely possible to keep the official PlatformIO IDE extension and simply force it to use the community-updated Espressif 3.x core. You can do this by pasting a custom GitHub URL into the `platformio.ini` file of your existing projects:
+
+```ini
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/stable/platform-espressif32.zip
+```
+
+This workaround functions perfectly well, as documented [here](https://github.com/pioarduino/platform-espressif32). It gives you access to modern ESP32 chips (like the C6, H2, and P4), the latest ESP-IDF 5.x framework, and modern GCC compilers, all while staying within the standard PlatformIO environment. 
+
+## Why use the pioarduino-ide fork instead?
+
+If the URL workaround exists, why bother installing the `pioarduino` IDE extension? The added value comes down to convenience, future-proofing, and specialized tooling:
+
+* **Out-of-the-Box GUI Support:** With standard PlatformIO, the project creation wizard (PIO Home) is hardcoded to use the frozen, official Espressif 2.x registry. With `pioarduino-vscode-ide`, the GUI natively points to the updated community registry. When you click "New Project" and select an ESP32 board, it automatically generates a clean `platformio.ini` using the modern v3.x core without requiring you to copy-paste GitHub URLs every time.
+* **Insulation from Upstream Politics:** The business dispute between PlatformIO and Espressif is ongoing. Relying on a URL override in the official extension leaves your projects vulnerable if the official maintainers push an update that breaks compatibility with custom registry URLs. The fork completely decouples your IDE from the official registry, ensuring your Espressif development environment remains stable and community-driven.
+* **Choice of IntelliSense Backends:** The standard PlatformIO IDE strictly couples you to the Microsoft C/C++ extension for code completion and linting. The `pioarduino-vscode-ide` fork introduces a highly requested feature: the ability to decouple the IntelliSense engine, giving you the freedom to choose modern alternatives like `clangd` for embedded development.

--- a/WHY_THIS_FORK.md
+++ b/WHY_THIS_FORK.md
@@ -1,6 +1,6 @@
 # pioarduino-vscode-ide vs. PlatformIO IDE: Understanding the Added Value
 
-If you are considering switching your development environment, the most important thing to know upfront is this: **pioarduino-vscode-ide can do everything the original PlatformIO IDE does.** Becuse it is a direct fork of the original extension, it shares the exact same underlying engine and interface. If you develop for STM32, Atmel AVR, RP2040, or any other non-Espressif architecture, your workflow, compilation, and uploading will remain 100% identical and fully supported. 
+If you are considering switching your development environment, the most important thing to know upfront is this: **pioarduino-vscode-ide can do everything the original PlatformIO IDE does.** Because it is a direct fork of the original extension, it shares the exact same underlying engine and interface. If you develop for STM32, Atmel AVR, RP2040, or any other non-Espressif architecture, your workflow, compilation, and uploading will remain 100% identical and fully supported. 
 
 Here is a breakdown of where the two diverge and the specific added value the `pioarduino` fork brings to the table.
 
@@ -14,7 +14,7 @@ platform = https://github.com/pioarduino/platform-espressif32/releases/download/
 
 This workaround functions perfectly well, as documented [here](https://github.com/pioarduino/platform-espressif32). It gives you access to modern ESP32 chips (like the C6, H2, and P4), the latest ESP-IDF 5.x framework, and modern GCC compilers, all while staying within the standard PlatformIO environment. 
 
-## Why use the pioarduino-ide fork instead?
+## Why use the pioarduino-vscode-ide fork instead?
 
 If the URL workaround exists, why bother installing the `pioarduino` IDE extension? The added value comes down to convenience, future-proofing, and specialized tooling:
 


### PR DESCRIPTION
This pull request improves the documentation to clarify the unique value of the `pioarduino-vscode-ide` fork compared to the official PlatformIO IDE. It introduces a new document explaining the benefits of using this fork, and updates the `README.md` to link to this explanation.

This change was requested and discussed in [issue #66](https://github.com/pioarduino/pioarduino-vscode-ide/issues/66).

**Documentation enhancements:**

* Added a new file, `WHY_THIS_FORK.md`, that details the differences between `pioarduino-vscode-ide` and the official PlatformIO IDE, highlighting added convenience, stability, and new features such as out-of-the-box GUI support for the updated Espressif core and the ability to choose alternative IntelliSense backends.
* Updated `README.md` to include a section linking to the new `WHY_THIS_FORK.md` document, making it easier for users to understand why they might want to use this fork.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "Why use this fork?" section plus a complementary document comparing this fork to the official PlatformIO IDE and explaining alternative workflows.
  * Describes benefits: project creation GUI that generates modern project configs without manual URL overrides, reduced coupling to upstream registry changes, and the ability to choose alternative IntelliSense backends (e.g., clangd).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->