### PR TITLE
add support for espressif clangd (#15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the **pioarduino IDE** VSCode extension are documented in
 
 ---
 
+## [1.3.8] - 2026-04-14
+
+### ✨ New Features
+
+- **Automatic Espressif clangd detection** — the extension now automatically discovers and uses Espressif's patched clangd from the PlatformIO packages directory (`tool-clangd-esp` or `toolchain-clang-esp`). This clangd variant has native support for Xtensa and ESP RISC-V custom ISA extensions (`xespv`, `xesploop`, `xespdsp`, etc.) that the upstream clangd does not understand, providing accurate IntelliSense for ESP32 targets.
+
+---
+
 ## [1.3.7] - 2026-04-12
 
 ### 📦 Dependencies

--- a/docs/intellisense.md
+++ b/docs/intellisense.md
@@ -91,9 +91,15 @@ To fix this, the extension:
 2. Recursively walks the project directory for all C/C++ source and header files (`.h`, `.hpp`, `.c`, `.cpp`, `.cc`, `.cxx`, `.ino`), skipping `node_modules`, `.pio`, `.git`, `build`, and `__pycache__`.
 3. For every file not already in the compilation database, creates a synthetic entry by cloning the template's `arguments` array, replacing the source file path and redirecting `-o` to `/dev/null` (or `NUL` on Windows).
 
-#### Step 6: Configure clangd Arguments
+#### Step 6: Configure clangd Path and Arguments
 
-`ensureClangdArgs()` updates the `clangd.arguments` workspace setting to include:
+`ensureClangdArgs()` first checks whether Espressif's patched clangd is available in the PlatformIO packages directory. Espressif's clangd has native support for Xtensa and ESP RISC-V custom ISA extensions (`xespv`, `xesploop`, `xespdsp`, etc.) that the upstream clangd does not understand. If found, it sets `clangd.path` to point to this binary. The search order is:
+
+1. `packages/tool-clangd-esp/bin/clangd` — dedicated lightweight clangd package (`clangd.exe` on Windows)
+2. `packages/tool-clangd-esp/esp-clangd/bin/clangd` — legacy layout of the dedicated package (`clangd.exe` on Windows)
+3. `packages/toolchain-clang-esp/esp-clang/bin/clangd` — bundled in the full Espressif clang toolchain (`clangd.exe` on Windows)
+
+It also updates the `clangd.arguments` workspace setting to include:
 
 - **`--compile-commands-dir=<projectDir>`** — tells clangd where to find `compile_commands.json`.
 - **`--query-driver=<glob>`** — allows clangd to query PlatformIO's cross-compilers for built-in system include paths. The glob covers `toolchain-*/bin/*` and `tool-*/bin/*` under the PlatformIO core directory. Without this, clangd cannot resolve system headers for embedded targets (xtensa, arm, riscv, etc.).
@@ -124,6 +130,7 @@ Extension Activation
                  │    └─ Write back as arguments arrays
                  │
                  ├─ ensureClangdArgs(projectDir)
+                 │    ├─ clangd.path → Espressif clangd (if installed)
                  │    ├─ --compile-commands-dir
                  │    └─ --query-driver
                  │

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pioarduino-ide",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "icon": "assets/images/pioarduino-128x128.png",
   "publisher": "pioarduino",
   "engines": {

--- a/src/intellisense.js
+++ b/src/intellisense.js
@@ -330,6 +330,36 @@ export async function fixupCompileCommands(projectDir) {
   await fs.writeFile(ccPath, JSON.stringify(entries, null, 2) + '\n', 'utf-8');
 }
 
+/**
+ * Search for Espressif's clangd binary in the PlatformIO packages directory.
+ *
+ * Espressif ships a patched clangd that understands Xtensa and ESP RISC-V
+ * custom extensions (xespv, xesploop, xespdsp, etc.) natively — the upstream
+ * clangd does not.  The binary may live in:
+ *   1. A dedicated clangd package:  packages/tool-clangd-esp/esp-clangd/bin/clangd
+ *   2. The full clang toolchain:    packages/toolchain-clang-esp/esp-clang/bin/clangd
+ *
+ * Returns the absolute path to the clangd binary, or null if not found.
+ */
+async function findEspClangd() {
+  const packagesDir = path.join(pioNodeHelpers.core.getCoreDir(), 'packages');
+  const exe = IS_WINDOWS ? 'clangd.exe' : 'clangd';
+  const candidates = [
+    path.join(packagesDir, 'tool-clangd-esp', 'bin', exe),
+    path.join(packagesDir, 'tool-clangd-esp', 'esp-clangd', 'bin', exe),
+    path.join(packagesDir, 'toolchain-clang-esp', 'esp-clang', 'bin', exe),
+  ];
+  for (const candidate of candidates) {
+    try {
+      await fs.access(candidate);
+      return candidate;
+    } catch {
+      // not installed here
+    }
+  }
+  return null;
+}
+
 export async function ensureClangdArgs(projectDir) {
   if (
     getActiveBackendId() !== 'clangd' ||
@@ -342,6 +372,19 @@ export async function ensureClangdArgs(projectDir) {
   const currentArgs = config.get('arguments') || [];
   const newArgs = [...currentArgs];
   let changed = false;
+
+  // Use Espressif's clangd when available — it has native Xtensa / ESP RISC-V
+  // support which the stock clangd lacks.
+  const espClangd = await findEspClangd();
+  if (espClangd) {
+    const inspected = config.inspect('path');
+    const currentPath = inspected
+      ? (inspected.workspaceValue ?? inspected.globalValue)
+      : undefined;
+    if (currentPath !== espClangd) {
+      await config.update('path', espClangd, vscode.ConfigurationTarget.Workspace);
+    }
+  }
 
   // --compile-commands-dir: tell clangd where compile_commands.json lives
   const compileCommandsFlag = `--compile-commands-dir=${projectDir}`;

--- a/src/main.js
+++ b/src/main.js
@@ -173,8 +173,10 @@ class PlatformIOVSCodeExtension {
   }
 
   patchOSEnviron() {
+    const { getActiveBackendId } = require('./intellisense');
     const extraVars = {
       PLATFORMIO_IDE: utils.getIDEVersion(),
+      PLATFORMIO_IDE_INTELLISENSE_ENGINE: getActiveBackendId(),
     };
     // handle HTTP proxy settings
     const http_proxy = vscode.workspace.getConfiguration('http').get('proxy');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic detection and use of Espressif's patched clangd for improved IntelliSense support on ESP32 targets with enhanced accuracy for custom ISA extensions (Xtensa and ESP RISC-V).

* **Documentation**
  * Updated clangd backend configuration documentation.

* **Chores**
  * Version bumped to 1.3.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->