### PR TITLE
Ensure compile_commands.json exists for clangd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the **pioarduino IDE** VSCode extension are documented in
 
 ---
 
+## [1.3.12] - 2026-04-17
+
+### ✨ Improvements
+
+- **clangd: auto-generate `compile_commands.json`** — when the clangd backend is active and `compile_commands.json` is missing (e.g. first open or after a clean), the extension now automatically runs `pio run --target compiledb` to generate it.
+
+---
+
 ## [1.3.11] - 2026-04-17
 
 ### 🐛 Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pioarduino-ide",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "icon": "assets/images/pioarduino-128x128.png",
   "publisher": "pioarduino",
   "engines": {

--- a/src/intellisense.js
+++ b/src/intellisense.js
@@ -168,13 +168,30 @@ export async function ensureCompileCommands(projectDir) {
   } catch {
     // file does not exist – generate it
   }
-  try {
-    await pioNodeHelpers.core.getPIOCommandOutput(['run', '--target', 'compiledb'], {
-      projectDir,
-    });
-  } catch (err) {
-    console.warn(`Failed to generate compile_commands.json: ${err.message}`);
-  }
+  // Run in background with a progress notification so the UI stays responsive.
+  vscode.window.withProgress(
+    {
+      location: vscode.ProgressLocation.Notification,
+      title: 'PlatformIO: Generating compile_commands.json…',
+      cancellable: false,
+    },
+    async () => {
+      try {
+        await pioNodeHelpers.core.getPIOCommandOutput(
+          ['run', '--target', 'compiledb'],
+          { projectDir },
+        );
+        // Post-process the freshly generated file (same steps as onDidRebuildIndex).
+        await fixupCompileCommands(projectDir);
+        await ensureClangdConfig(projectDir);
+        await notifyRescanBackend();
+      } catch (err) {
+        vscode.window.showErrorMessage(
+          `Failed to generate compile_commands.json: ${err.message}`,
+        );
+      }
+    },
+  );
 }
 
 /**

--- a/src/intellisense.js
+++ b/src/intellisense.js
@@ -147,6 +147,37 @@ function collectOtherBackendValues(activeId) {
 }
 
 /**
+ * Ensure compile_commands.json exists for clangd.
+ *
+ * When a project is opened with the clangd backend and no
+ * compile_commands.json is present yet (e.g. first open, or after a clean),
+ * we generate it by running `pio run --target compiledb`.
+ */
+export async function ensureCompileCommands(projectDir) {
+  if (
+    getActiveBackendId() !== 'clangd' ||
+    !projectDir ||
+    !isBackendExtensionInstalled()
+  ) {
+    return;
+  }
+  const ccPath = path.join(projectDir, 'compile_commands.json');
+  try {
+    await fs.access(ccPath);
+    return; // already exists
+  } catch {
+    // file does not exist – generate it
+  }
+  try {
+    await pioNodeHelpers.core.getPIOCommandOutput(['run', '--target', 'compiledb'], {
+      projectDir,
+    });
+  } catch (err) {
+    console.warn(`Failed to generate compile_commands.json: ${err.message}`);
+  }
+}
+
+/**
  * Post-process compile_commands.json so clangd works correctly:
  *  1. Resolve bare compiler names to absolute paths so --query-driver matches.
  *  2. Convert relative -I include paths to absolute so clangd finds headers.

--- a/src/project/manager.js
+++ b/src/project/manager.js
@@ -12,6 +12,7 @@ import { disposeSubscriptions, notifyError } from '../utils';
 import {
   ensureClangdArgs,
   ensureClangdConfig,
+  ensureCompileCommands,
   ensureLaunchJson,
   fixupCompileCommands,
   getActiveBackend,
@@ -243,6 +244,7 @@ export default class ProjectManager {
     ) {
       disposeSubscriptions(this.internalSubscriptions);
       await this._pool.switch(projectDir);
+      await ensureCompileCommands(projectDir);
       await ensureClangdArgs(projectDir);
       this._taskManager = new ProjectTaskManager(projectDir, observer);
       this.internalSubscriptions.push(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The extension now automatically generates the compile database when the clangd backend is active and the file is missing.

* **Chores**
  * Version bumped to 1.3.12

<!-- end of auto-generated comment: release notes by coderabbit.ai -->