### PR TITLE
fix: clangd: generate `compile_commands.json` only for the active environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the **pioarduino IDE** VSCode extension are documented in
 
 ---
 
+## [1.3.13] - 2026-04-17
+
+### 🐛 Bug Fixes
+
+- **clangd: generate `compile_commands.json` only for the active environment** — `ensureCompileCommands` now passes the selected environment to `pio run --target compiledb --environment <env>` so only the active env is built instead of all environments.
+
+---
+
 ## [1.3.12] - 2026-04-17
 
 ### ✨ Improvements

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pioarduino-ide",
-  "version": "1.3.12",
+  "version": "1.3.13",
   "icon": "assets/images/pioarduino-128x128.png",
   "publisher": "pioarduino",
   "engines": {
@@ -897,7 +897,7 @@
   "devDependencies": {
     "@types/node": "~25",
     "@types/vscode": "~1.95.0",
-    "@vscode/vsce": "~3.7.1",
+    "@vscode/vsce": "~3.9.0",
     "eslint": "^8",
     "eslint-import-resolver-webpack": "~0.13.11",
     "eslint-plugin-import": "^2.32.0",

--- a/src/intellisense.js
+++ b/src/intellisense.js
@@ -153,7 +153,7 @@ function collectOtherBackendValues(activeId) {
  * compile_commands.json is present yet (e.g. first open, or after a clean),
  * we generate it by running `pio run --target compiledb`.
  */
-export async function ensureCompileCommands(projectDir) {
+export async function ensureCompileCommands(projectDir, activeEnv) {
   if (
     getActiveBackendId() !== 'clangd' ||
     !projectDir ||
@@ -178,10 +178,11 @@ export async function ensureCompileCommands(projectDir) {
     },
     async () => {
       try {
-        await pioNodeHelpers.core.getPIOCommandOutput(
-          ['run', '--target', 'compiledb'],
-          { projectDir },
-        );
+        const args = ['run', '--target', 'compiledb'];
+        if (activeEnv) {
+          args.push('--environment', activeEnv);
+        }
+        await pioNodeHelpers.core.getPIOCommandOutput(args, { projectDir });
         // Post-process the freshly generated file (same steps as onDidRebuildIndex).
         await fixupCompileCommands(projectDir);
         await ensureClangdConfig(projectDir);

--- a/src/project/manager.js
+++ b/src/project/manager.js
@@ -244,7 +244,7 @@ export default class ProjectManager {
     ) {
       disposeSubscriptions(this.internalSubscriptions);
       await this._pool.switch(projectDir);
-      await ensureCompileCommands(projectDir);
+      await ensureCompileCommands(projectDir, observer.getSelectedEnv());
       await ensureClangdArgs(projectDir);
       this._taskManager = new ProjectTaskManager(projectDir, observer);
       this.internalSubscriptions.push(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed compile commands generation to target only the currently selected PlatformIO environment instead of generating for all environments.

* **Chores**
  * Updated development dependencies and bumped version to 1.3.13.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->