### PR TITLE
Bump version 1.3.15

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -31,7 +31,6 @@ node_modules/**/.github/**
 node_modules/**/appveyor.yml
 node_modules/**/.flowconfig
 node_modules/**/*.flow
-node_modules/**/*.min.js
 node_modules/**/tsconfig.json
 node_modules/**/webpack.config.js
 node_modules/**/jest.config.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the **pioarduino IDE** VSCode extension are documented in
 
 ---
 
+## [1.3.14] - 2026-04-18
+
+### 🐛 Bug Fixes
+
+- **clangd: avoid duplicates in `.clangd`** by checking if espressif specific settings are already applied.
+
+---
+
 ## [1.3.13] - 2026-04-17
 
 ### 🐛 Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the **pioarduino IDE** VSCode extension are documented in
 
 ---
 
+## [1.3.15] - 2026-04-19
+
+### 🔧 Maintenance
+
+- **Update / Refactor `pioarduino-node-helpers`** to v12.4.7. Python no more needed for pioarduino IDE install and use.
+
+---
+
 ## [1.3.14] - 2026-04-18
 
 ### 🐛 Bug Fixes
@@ -72,7 +80,7 @@ All notable changes to the **pioarduino IDE** VSCode extension are documented in
 
 ### 📦 Dependencies
 
-- Update `pioarduino-node-helpers` to  v12.4.4
+- Update `pioarduino-node-helpers` to v12.4.4
 
 ---
 
@@ -105,7 +113,7 @@ All notable changes to the **pioarduino IDE** VSCode extension are documented in
 
 ### 📦 Dependencies
 
-- Update `pioarduino-vscode-debug` to  v1.1.3
+- Update `pioarduino-vscode-debug` to v1.1.3
 
 ---
 
@@ -125,7 +133,7 @@ All notable changes to the **pioarduino IDE** VSCode extension are documented in
 
 ### 📦 Dependencies
 
-- Update `pioarduino-vscode-debug` to  v1.1.2
+- Update `pioarduino-vscode-debug` to v1.1.2
 
 ### 🔧 Maintenance
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pioarduino-ide",
-  "version": "1.3.13",
+  "version": "1.3.14",
   "icon": "assets/images/pioarduino-128x128.png",
   "publisher": "pioarduino",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -888,7 +888,7 @@
   },
   "dependencies": {
     "fs-plus": "~3.1.1",
-    "pioarduino-node-helpers": "~12.4.4",
+    "pioarduino-node-helpers": "~12.4.5",
     "pioarduino-vscode-debug": "~1.1.4"
   },
   "overrides": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pioarduino-ide",
-  "version": "1.3.14",
+  "version": "1.3.15",
   "icon": "assets/images/pioarduino-128x128.png",
   "publisher": "pioarduino",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -888,10 +888,8 @@
   },
   "dependencies": {
     "fs-plus": "~3.1.1",
-    "pioarduino-node-helpers": "~12.4.5",
-    "pioarduino-vscode-debug": "~1.1.4"
-  },
-  "overrides": {
+    "pioarduino-node-helpers": "~12.4.7",
+    "pioarduino-vscode-debug": "~1.1.4",
     "tar": "^7.5.13"
   },
   "devDependencies": {

--- a/src/intellisense.js
+++ b/src/intellisense.js
@@ -434,11 +434,6 @@ export async function ensureClangdConfig(projectDir) {
   }
   const configPath = path.join(projectDir, '.clangd');
 
-  // Desired YAML block
-  const builtinHeadersBlock =
-    'CompileFlags:\n  BuiltinHeaders: QueryDriver\n' +
-    'Diagnostics:\n  Suppress: [pp_expects_filename]\n';
-
   let existing = '';
   try {
     existing = await fs.readFile(configPath, 'utf-8');
@@ -446,15 +441,26 @@ export async function ensureClangdConfig(projectDir) {
     // file does not exist yet
   }
 
+  const hasBuiltinHeaders = existing.includes('BuiltinHeaders');
+  const hasSuppressDiag = existing.includes('pp_expects_filename');
+
   // Already contains both directives – nothing to do
-  if (existing.includes('BuiltinHeaders') && existing.includes('pp_expects_filename')) {
+  if (hasBuiltinHeaders && hasSuppressDiag) {
     return;
   }
 
+  // Build only the missing parts
+  const parts = [];
+  if (!hasBuiltinHeaders) {
+    parts.push('CompileFlags:\n  BuiltinHeaders: QueryDriver');
+  }
+  if (!hasSuppressDiag) {
+    parts.push('Diagnostics:\n  Suppress: [pp_expects_filename]');
+  }
+  const block = parts.join('\n') + '\n';
+
   // Prepend the block (separated by ---) so we don't clobber user settings
-  const content = existing
-    ? builtinHeadersBlock + '---\n' + existing
-    : builtinHeadersBlock;
+  const content = existing ? block + '---\n' + existing : block;
 
   await fs.writeFile(configPath, content, 'utf-8');
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where duplicate Espressif-specific settings could appear in clangd configuration, improving code intelligence reliability.

* **Chores**
  * Released version 1.3.15.
  * Updated key dependencies to latest compatible versions.
  * Refined package dependency management configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->