### PR TITLE
fix clangd tokenizer: Windows backslashes are path separators

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,8 @@ jobs:
           node-version: 20
       - name: Install NPM
         run: npm install
+      - name: Run tests
+        run: node src/shellTokenize.test.js
       - name: Compile vsix package
         run: |
           npm run build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,19 @@ All notable changes to the **pioarduino IDE** VSCode extension are documented in
 
 ### 🐛 Bug Fixes
 
+- **clangd: fix `compile_commands.json` generation timing** — `ensureCompileCommands` no longer runs a separate `pio run --target compiledb` that could race with the observer's own rebuild. Instead it triggers the rebuild via the project observer, which waits for PIO's full pre-build process (LDF, dependency resolution) to complete.
 - **clangd: fix `compile_commands.json` tokenization on Windows** — implement the canonical LLVM/MSVC counted-backslash rule in `shellTokenize` so that backslash-escaped quotes and values with spaces (e.g. `-DARDUINO_BOARD=\"Espressif ESP32-S3-DevKitC-1\"`) are no longer split into multiple bogus arguments.
 - **clangd: resolve compiler paths on Windows** — `resolveCompiler` now tries the `.exe` extension when looking up bare compiler names (e.g. `riscv32-esp-elf-gcc` → `riscv32-esp-elf-gcc.exe`), so cross-compiler paths are correctly resolved in `compile_commands.json`.
+- **shellTokenize: treat tabs, `\r`, and `\n` as delimiters** — previously only spaces were recognized as token separators; tabs and carriage returns were appended literally to tokens.
+- **shellTokenize: single quotes are literal on Windows** — matches MSVC/LLVM behavior where only double quotes are quoting characters.
+
+### ♻️ Refactor
+
+- **Extract `shellTokenize` into its own module** (`src/shellTokenize.js`) — accepts an `isWindows` parameter, eliminating the duplicated copy in tests and preventing drift.
 
 ### 🧪 Tests
 
-- **Add unit tests for `shellTokenize`** — covers POSIX and Windows branches including path preservation, MSVC backslash-quote counting, empty quoted tokens, and edge cases. Tests run in CI (`build.yml`) and fail the workflow on regression.
+- **Add unit tests for `shellTokenize`** — covers POSIX and Windows branches including path preservation, MSVC backslash-quote counting, tab/CR/LF delimiters, Windows literal single quotes, empty quoted tokens, and edge cases. Tests run in CI (`build.yml`) and fail the workflow on regression.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to the **pioarduino IDE** VSCode extension are documented in
 
 ---
 
+## [1.3.16] - 2026-04-19
+
+### 🐛 Bug Fixes
+
+- **clangd: fix `compile_commands.json` tokenization on Windows** — implement the canonical LLVM/MSVC counted-backslash rule in `shellTokenize` so that backslash-escaped quotes and values with spaces (e.g. `-DARDUINO_BOARD=\"Espressif ESP32-S3-DevKitC-1\"`) are no longer split into multiple bogus arguments.
+- **clangd: resolve compiler paths on Windows** — `resolveCompiler` now tries the `.exe` extension when looking up bare compiler names (e.g. `riscv32-esp-elf-gcc` → `riscv32-esp-elf-gcc.exe`), so cross-compiler paths are correctly resolved in `compile_commands.json`.
+
+### 🧪 Tests
+
+- **Add unit tests for `shellTokenize`** — covers POSIX and Windows branches including path preservation, MSVC backslash-quote counting, empty quoted tokens, and edge cases. Tests run in CI (`build.yml`) and fail the workflow on regression.
+
+---
+
 ## [1.3.15] - 2026-04-19
 
 ### 🔧 Maintenance

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pioarduino-ide",
-  "version": "1.3.15",
+  "version": "1.3.16",
   "icon": "assets/images/pioarduino-128x128.png",
   "publisher": "pioarduino",
   "engines": {

--- a/src/intellisense.js
+++ b/src/intellisense.js
@@ -274,9 +274,10 @@ export async function fixupCompileCommands(projectDir) {
         }
         const candidate = path.join(packagesDir, d, 'bin', bare);
         // On Windows, PIO emits bare names without .exe – try both variants.
-        const candidates = IS_WINDOWS && !bare.endsWith('.exe')
-          ? [candidate + '.exe', candidate]
-          : [candidate];
+        const candidates =
+          IS_WINDOWS && !bare.endsWith('.exe')
+            ? [candidate + '.exe', candidate]
+            : [candidate];
         for (const c of candidates) {
           try {
             await fs.access(c);

--- a/src/intellisense.js
+++ b/src/intellisense.js
@@ -37,18 +37,33 @@ function shellTokenize(cmd) {
     const ch = cmd[i];
     if (ch === '\\' && !inSingle && i + 1 < cmd.length) {
       if (IS_WINDOWS) {
-        // On Windows backslashes are path separators – only treat \" as an
-        // escape (literal double-quote) so that values like
-        //   -DBOARD=\"Espressif ESP32\"  are kept as a single token.
-        // All other \x sequences keep the backslash (preserving paths).
-        if (cmd[i + 1] === '"') {
-          current += '"';
+        // LLVM/MSVC backslash-quote rule: count consecutive backslashes
+        // preceding a double-quote.  2n backslashes + " → n backslashes,
+        // toggle quote mode.  2n+1 backslashes + " → n backslashes + literal
+        // '"' (no toggle).  Backslashes NOT followed by a double-quote are
+        // kept literally (preserving Windows paths like C:\SDK\include).
+        let numSlashes = 0;
+        while (i < cmd.length && cmd[i] === '\\') {
+          numSlashes++;
           i++;
-          hasContent = true;
-        } else {
-          current += ch;
-          hasContent = true;
         }
+        if (i < cmd.length && cmd[i] === '"') {
+          // Backslashes followed by a double-quote
+          const literalSlashes = Math.floor(numSlashes / 2);
+          current += '\\'.repeat(literalSlashes);
+          if (numSlashes % 2 === 1) {
+            // Odd run: last backslash escapes the quote → literal '"'
+            current += '"';
+          } else {
+            // Even run: quote is unescaped → toggle quote mode
+            inDouble = !inDouble;
+          }
+        } else {
+          // Backslashes not followed by a quote → all literal
+          current += '\\'.repeat(numSlashes);
+          i--; // re-examine the non-quote character on next iteration
+        }
+        hasContent = true;
       } else {
         current += cmd[++i];
         hasContent = true;

--- a/src/intellisense.js
+++ b/src/intellisense.js
@@ -15,80 +15,11 @@ import {
 import { extension } from './main';
 import { promises as fs } from 'fs';
 import path from 'path';
+import shellTokenizeImpl from './shellTokenize';
 import vscode from 'vscode';
 
-/**
- * Tokenize a shell command string into an argv array.
- *
- * On POSIX this follows GNU shell rules (backslash escapes, single & double
- * quotes).  On Windows backslashes are NOT treated as escape characters so
- * that paths like C:\SDK\include survive intact – matching the behaviour of
- * LLVM's TokenizeWindowsCommandLine.
- *
- * Empty quoted strings ("" or '') produce an empty-string token.
- */
 function shellTokenize(cmd) {
-  const tokens = [];
-  let current = '';
-  let hasContent = false;
-  let inSingle = false;
-  let inDouble = false;
-  for (let i = 0; i < cmd.length; i++) {
-    const ch = cmd[i];
-    if (ch === '\\' && !inSingle && i + 1 < cmd.length) {
-      if (IS_WINDOWS) {
-        // LLVM/MSVC backslash-quote rule: count consecutive backslashes
-        // preceding a double-quote.  2n backslashes + " → n backslashes,
-        // toggle quote mode.  2n+1 backslashes + " → n backslashes + literal
-        // '"' (no toggle).  Backslashes NOT followed by a double-quote are
-        // kept literally (preserving Windows paths like C:\SDK\include).
-        let numSlashes = 0;
-        while (i < cmd.length && cmd[i] === '\\') {
-          numSlashes++;
-          i++;
-        }
-        if (i < cmd.length && cmd[i] === '"') {
-          // Backslashes followed by a double-quote
-          const literalSlashes = Math.floor(numSlashes / 2);
-          current += '\\'.repeat(literalSlashes);
-          if (numSlashes % 2 === 1) {
-            // Odd run: last backslash escapes the quote → literal '"'
-            current += '"';
-          } else {
-            // Even run: quote is unescaped → toggle quote mode
-            inDouble = !inDouble;
-          }
-        } else {
-          // Backslashes not followed by a quote → all literal
-          current += '\\'.repeat(numSlashes);
-          i--; // re-examine the non-quote character on next iteration
-        }
-        hasContent = true;
-      } else {
-        current += cmd[++i];
-        hasContent = true;
-      }
-    } else if (ch === "'" && !inDouble) {
-      inSingle = !inSingle;
-      hasContent = true;
-    } else if (ch === '"' && !inSingle) {
-      inDouble = !inDouble;
-      hasContent = true;
-    } else if (ch === ' ' && !inSingle && !inDouble) {
-      if (current.length > 0 || hasContent) {
-        tokens.push(current);
-        current = '';
-        hasContent = false;
-      }
-    } else {
-      current += ch;
-      hasContent = true;
-    }
-  }
-  if (current.length > 0 || hasContent) {
-    tokens.push(current);
-  }
-  return tokens;
+  return shellTokenizeImpl(cmd, IS_WINDOWS);
 }
 
 /** Include-path flags that accept a directory argument (longest first). */

--- a/src/intellisense.js
+++ b/src/intellisense.js
@@ -258,12 +258,18 @@ export async function fixupCompileCommands(projectDir) {
           continue;
         }
         const candidate = path.join(packagesDir, d, 'bin', bare);
-        try {
-          await fs.access(candidate);
-          resolveCache.set(bare, candidate);
-          return candidate;
-        } catch {
-          // not here
+        // On Windows, PIO emits bare names without .exe – try both variants.
+        const candidates = IS_WINDOWS && !bare.endsWith('.exe')
+          ? [candidate + '.exe', candidate]
+          : [candidate];
+        for (const c of candidates) {
+          try {
+            await fs.access(c);
+            resolveCache.set(bare, c);
+            return c;
+          } catch {
+            // not here
+          }
         }
       }
     } catch {

--- a/src/intellisense.js
+++ b/src/intellisense.js
@@ -26,23 +26,87 @@ function shellTokenize(cmd) {
 const INCLUDE_FLAGS = ['-idirafter', '-isystem', '-iquote', '-I'];
 
 /**
+ * Flags whose argument is a *file* path, always in separated form only
+ * (GCC/Clang never accept a joined form like -include<file>).
+ */
+const INCLUDE_FILE_FLAGS = ['-include-pch', '-include', '-imacros'];
+
+/**
  * Convert relative include-path arguments to absolute.
- * Handles both joined (-Ipath) and separated (-I path) forms for every flag
- * in INCLUDE_FLAGS.
+ *
+ * For directory-style flags (-I, -isystem, -iquote, -idirafter):
+ *   resolve relative to `dir`.
+ *
+ * For file-style flags (-include, -include-pch, -imacros):
+ *   search the full include-path list (both absolute AND relative entries,
+ *   all pre-resolved to absolute) for the file, then fall back to `dir`.
+ *   This mirrors the compiler's own resolution order.
  */
 function absolutizeIncludes(args, dir) {
+  // ── Pass 1: collect every include directory (absolutize relative ones). ──
+  const includeDirs = [];
   for (let i = 1; i < args.length; i++) {
     const a = args[i];
-    // Separated form: flag <path>
-    const separatedMatch = INCLUDE_FLAGS.find((f) => a === f);
-    if (separatedMatch && i + 1 < args.length) {
+
+    // Separated form:  -I <path>
+    const sep = INCLUDE_FLAGS.find((f) => a === f);
+    if (sep && i + 1 < args.length) {
+      const p = args[i + 1];
+      // ★ key change: absolutize relative dirs here, not just absolute ones
+      includeDirs.push(path.isAbsolute(p) ? p : path.join(dir, p));
+      i++;
+      continue;
+    }
+
+    // Joined form:  -I<path>
+    for (const flag of INCLUDE_FLAGS) {
+      if (a.startsWith(flag) && a.length > flag.length) {
+        const p = a.slice(flag.length);
+        includeDirs.push(path.isAbsolute(p) ? p : path.join(dir, p));
+        break;
+      }
+    }
+  }
+
+  // ── Pass 2: absolutize every include argument. ──
+  for (let i = 1; i < args.length; i++) {
+    const a = args[i];
+
+    // Separated directory flag:  -I <path>
+    const sepDirMatch = INCLUDE_FLAGS.find((f) => a === f);
+    if (sepDirMatch && i + 1 < args.length) {
       if (!path.isAbsolute(args[i + 1])) {
         args[i + 1] = path.join(dir, args[i + 1]);
       }
       i++;
       continue;
     }
-    // Joined form: flag<path> (match longest prefix first)
+
+    // Separated file flag:  -include <file>
+    const sepFileMatch = INCLUDE_FILE_FLAGS.find((f) => a === f);
+    if (sepFileMatch && i + 1 < args.length) {
+      const rel = args[i + 1];
+      if (!path.isAbsolute(rel)) {
+        // Walk include dirs in order (same as the compiler would).
+        let resolved = null;
+        for (const d of includeDirs) {
+          const candidate = path.join(d, rel);
+          try {
+            require('fs').accessSync(candidate);
+            resolved = candidate;
+            break;
+          } catch {
+            // not in this dir — keep searching
+          }
+        }
+        // Fallback: resolve relative to compilation dir (should be rare).
+        args[i + 1] = resolved ?? path.join(dir, rel);
+      }
+      i++;
+      continue;
+    }
+
+    // Joined directory flag:  -I<path>
     for (const flag of INCLUDE_FLAGS) {
       if (a.startsWith(flag) && a.length > flag.length) {
         const v = a.slice(flag.length);
@@ -108,17 +172,25 @@ function collectOtherBackendValues(activeId) {
 }
 
 /**
- * Ensure compile_commands.json exists for clangd.
+ * Ensure compile_commands.json will be generated for clangd.
  *
  * When a project is opened with the clangd backend and no
  * compile_commands.json is present yet (e.g. first open, or after a clean),
- * we generate it by running `pio run --target compiledb`.
+ * we trigger a rebuild via the project observer.  The observer's
+ * `rebuildIndex` runs `pio run --target compiledb` which waits for PIO's
+ * full pre-build process (LDF, dependency resolution, etc.) to complete
+ * before writing compile_commands.json.  The `onDidRebuildIndex` callback
+ * then post-processes the file.
+ *
+ * This avoids a race where a separate `pio run` would start in parallel
+ * with the observer's own rebuild.
  */
-export async function ensureCompileCommands(projectDir, activeEnv) {
+export async function ensureCompileCommands(projectDir, observer) {
   if (
     getActiveBackendId() !== 'clangd' ||
     !projectDir ||
-    !isBackendExtensionInstalled()
+    !isBackendExtensionInstalled() ||
+    !observer
   ) {
     return;
   }
@@ -127,36 +199,9 @@ export async function ensureCompileCommands(projectDir, activeEnv) {
     await fs.access(ccPath);
     return; // already exists
   } catch {
-    // file does not exist – generate it
+    // file does not exist – trigger a rebuild via the observer
   }
-  // Run in background with a progress notification so the UI stays responsive.
-  // Intentionally not awaited: project switching should not block on `pio run`.
-  return vscode.window.withProgress(
-    {
-      location: vscode.ProgressLocation.Notification,
-      title: 'PlatformIO: Generating compile_commands.json…',
-      cancellable: false,
-    },
-    async () => {
-      try {
-        const args = ['run', '--target', 'compiledb'];
-        if (activeEnv) {
-          args.push('--environment', activeEnv);
-        }
-        await pioNodeHelpers.core.getPIOCommandOutput(args, { projectDir });
-        // Post-process the freshly generated file (same steps as onDidRebuildIndex).
-        await fixupCompileCommands(projectDir);
-        await ensureClangdConfig(projectDir);
-        await ensureClangdArgs(projectDir);
-        await ensureLaunchJson(projectDir);
-        await notifyRescanBackend();
-      } catch (err) {
-        vscode.window.showErrorMessage(
-          `Failed to generate compile_commands.json: ${err && err.message ? err.message : err}`,
-        );
-      }
-    },
-  );
+  observer.rebuildIndex({ force: true });
 }
 
 /**

--- a/src/intellisense.js
+++ b/src/intellisense.js
@@ -42,7 +42,7 @@ const INCLUDE_FILE_FLAGS = ['-include-pch', '-include', '-imacros'];
  *   all pre-resolved to absolute) for the file, then fall back to `dir`.
  *   This mirrors the compiler's own resolution order.
  */
-function absolutizeIncludes(args, dir) {
+async function absolutizeIncludes(args, dir) {
   // ── Pass 1: collect every include directory (absolutize relative ones). ──
   const includeDirs = [];
   for (let i = 1; i < args.length; i++) {
@@ -92,7 +92,7 @@ function absolutizeIncludes(args, dir) {
         for (const d of includeDirs) {
           const candidate = path.join(d, rel);
           try {
-            require('fs').accessSync(candidate);
+            await fs.access(candidate);
             resolved = candidate;
             break;
           } catch {
@@ -320,7 +320,7 @@ export async function fixupCompileCommands(projectDir) {
     }
 
     // 2. Convert relative include paths to absolute
-    absolutizeIncludes(args, dir);
+    await absolutizeIncludes(args, dir);
 
     // Write back as arguments array (preferred by clangd, avoids quoting issues)
     entry.arguments = args;

--- a/src/intellisense.js
+++ b/src/intellisense.js
@@ -35,9 +35,24 @@ function shellTokenize(cmd) {
   let inDouble = false;
   for (let i = 0; i < cmd.length; i++) {
     const ch = cmd[i];
-    if (!IS_WINDOWS && ch === '\\' && !inSingle && i + 1 < cmd.length) {
-      current += cmd[++i];
-      hasContent = true;
+    if (ch === '\\' && !inSingle && i + 1 < cmd.length) {
+      if (IS_WINDOWS) {
+        // On Windows backslashes are path separators – only treat \" as an
+        // escape (literal double-quote) so that values like
+        //   -DBOARD=\"Espressif ESP32\"  are kept as a single token.
+        // All other \x sequences keep the backslash (preserving paths).
+        if (cmd[i + 1] === '"') {
+          current += '"';
+          i++;
+          hasContent = true;
+        } else {
+          current += ch;
+          hasContent = true;
+        }
+      } else {
+        current += cmd[++i];
+        hasContent = true;
+      }
     } else if (ch === "'" && !inDouble) {
       inSingle = !inSingle;
       hasContent = true;

--- a/src/project/manager.js
+++ b/src/project/manager.js
@@ -244,7 +244,7 @@ export default class ProjectManager {
     ) {
       disposeSubscriptions(this.internalSubscriptions);
       await this._pool.switch(projectDir);
-      await ensureCompileCommands(projectDir, observer.getSelectedEnv());
+      await ensureCompileCommands(projectDir, this._pool.getActiveObserver());
       await ensureClangdArgs(projectDir);
       this._taskManager = new ProjectTaskManager(projectDir, observer);
       this.internalSubscriptions.push(

--- a/src/shellTokenize.js
+++ b/src/shellTokenize.js
@@ -57,13 +57,18 @@ function shellTokenize(cmd, isWindows) {
         current += cmd[++i];
         hasContent = true;
       }
-    } else if (ch === "'" && !inDouble) {
+    } else if (ch === "'" && !inDouble && !isWindows) {
+      // Single quotes toggle quoting on POSIX only; on Windows they are literal.
       inSingle = !inSingle;
       hasContent = true;
     } else if (ch === '"' && !inSingle) {
       inDouble = !inDouble;
       hasContent = true;
-    } else if (ch === ' ' && !inSingle && !inDouble) {
+    } else if (
+      (ch === ' ' || ch === '\t' || ch === '\r' || ch === '\n') &&
+      !inSingle &&
+      !inDouble
+    ) {
       if (current.length > 0 || hasContent) {
         tokens.push(current);
         current = '';

--- a/src/shellTokenize.js
+++ b/src/shellTokenize.js
@@ -1,0 +1,83 @@
+/**
+ * Tokenize a shell command string into an argv array.
+ *
+ * On POSIX this follows GNU shell rules (backslash escapes, single & double
+ * quotes).  On Windows backslashes are NOT treated as escape characters so
+ * that paths like C:\SDK\include survive intact – matching the behaviour of
+ * LLVM's TokenizeWindowsCommandLine.
+ *
+ * NOTE: The canonical MSVC rule also treats consecutive double-quotes ("")
+ * inside a quoted region as a single literal '"'.  We intentionally omit
+ * this because PlatformIO's compile_commands.json never produces that
+ * pattern — it uses backslash-escaping instead.
+ *
+ * Empty quoted strings ("" or '') produce an empty-string token.
+ *
+ * @param {string} cmd - The command string to tokenize.
+ * @param {boolean} isWindows - Use Windows (MSVC) tokenization rules.
+ */
+function shellTokenize(cmd, isWindows) {
+  const tokens = [];
+  let current = '';
+  let hasContent = false;
+  let inSingle = false;
+  let inDouble = false;
+  for (let i = 0; i < cmd.length; i++) {
+    const ch = cmd[i];
+    if (ch === '\\' && !inSingle && i + 1 < cmd.length) {
+      if (isWindows) {
+        // LLVM/MSVC backslash-quote rule: count consecutive backslashes
+        // preceding a double-quote.  2n backslashes + " → n backslashes,
+        // toggle quote mode.  2n+1 backslashes + " → n backslashes + literal
+        // '"' (no toggle).  Backslashes NOT followed by a double-quote are
+        // kept literally (preserving Windows paths like C:\SDK\include).
+        let numSlashes = 0;
+        while (i < cmd.length && cmd[i] === '\\') {
+          numSlashes++;
+          i++;
+        }
+        if (i < cmd.length && cmd[i] === '"') {
+          // Backslashes followed by a double-quote
+          const literalSlashes = Math.floor(numSlashes / 2);
+          current += '\\'.repeat(literalSlashes);
+          if (numSlashes % 2 === 1) {
+            // Odd run: last backslash escapes the quote → literal '"'
+            current += '"';
+          } else {
+            // Even run: quote is unescaped → toggle quote mode
+            inDouble = !inDouble;
+          }
+        } else {
+          // Backslashes not followed by a quote → all literal
+          current += '\\'.repeat(numSlashes);
+          i--; // re-examine the non-quote character on next iteration
+        }
+        hasContent = true;
+      } else {
+        current += cmd[++i];
+        hasContent = true;
+      }
+    } else if (ch === "'" && !inDouble) {
+      inSingle = !inSingle;
+      hasContent = true;
+    } else if (ch === '"' && !inSingle) {
+      inDouble = !inDouble;
+      hasContent = true;
+    } else if (ch === ' ' && !inSingle && !inDouble) {
+      if (current.length > 0 || hasContent) {
+        tokens.push(current);
+        current = '';
+        hasContent = false;
+      }
+    } else {
+      current += ch;
+      hasContent = true;
+    }
+  }
+  if (current.length > 0 || hasContent) {
+    tokens.push(current);
+  }
+  return tokens;
+}
+
+module.exports = shellTokenize;

--- a/src/shellTokenize.test.js
+++ b/src/shellTokenize.test.js
@@ -105,7 +105,12 @@ assertTokens(
 
 assertTokens('WIN: empty double-quoted token', 'a "" b', true, ['a', '', 'b']);
 
-assertTokens('WIN: empty single-quoted token', "a '' b", true, ['a', '', 'b']);
+assertTokens(
+  'WIN: single quotes are literal (not quoting characters)',
+  "a 'hello world' b",
+  true,
+  ['a', "'hello", "world'", 'b'],
+);
 
 assertTokens('WIN: backslashes before non-quote are literal', 'C:\\a\\b\\c d', true, [
   'C:\\a\\b\\c',
@@ -176,6 +181,34 @@ assertTokens(
 
 assertTokens('POSIX: trailing backslash (no char follows) preserved', 'abc\\', false, [
   'abc\\',
+]);
+
+// ─── Whitespace delimiters (tabs, \r) ───────────────────────────────────────
+
+assertTokens('WIN: tab as delimiter', 'a\tb\tc', true, ['a', 'b', 'c']);
+
+assertTokens('POSIX: tab as delimiter', 'a\tb\tc', false, ['a', 'b', 'c']);
+
+assertTokens(
+  'WIN: \\r\\n line ending does not leak \\r into token',
+  'gcc -c file.c\r\n',
+  true,
+  ['gcc', '-c', 'file.c'],
+);
+
+assertTokens(
+  'POSIX: \\r\\n line ending does not leak \\r into token',
+  'gcc -c file.c\r\n',
+  false,
+  ['gcc', '-c', 'file.c'],
+);
+
+assertTokens('WIN: tabs inside double-quoted string are literal', '"a\tb"', true, [
+  'a\tb',
+]);
+
+assertTokens('POSIX: tabs inside double-quoted string are literal', '"a\tb"', false, [
+  'a\tb',
 ]);
 
 // ─── Summary ────────────────────────────────────────────────────────────────

--- a/src/shellTokenize.test.js
+++ b/src/shellTokenize.test.js
@@ -2,69 +2,11 @@
  * Unit tests for shellTokenize.
  *
  * Run with:  node src/shellTokenize.test.js
- *
- * The function is duplicated here with an `isWindows` parameter so the tests
- * can exercise both platform branches without patching module-level constants.
  */
 
 'use strict';
 
-// --- shellTokenize (parameterized copy) ---
-
-function shellTokenize(cmd, isWindows) {
-  const tokens = [];
-  let current = '';
-  let hasContent = false;
-  let inSingle = false;
-  let inDouble = false;
-  for (let i = 0; i < cmd.length; i++) {
-    const ch = cmd[i];
-    if (ch === '\\' && !inSingle && i + 1 < cmd.length) {
-      if (isWindows) {
-        let numSlashes = 0;
-        while (i < cmd.length && cmd[i] === '\\') {
-          numSlashes++;
-          i++;
-        }
-        if (i < cmd.length && cmd[i] === '"') {
-          const literalSlashes = Math.floor(numSlashes / 2);
-          current += '\\'.repeat(literalSlashes);
-          if (numSlashes % 2 === 1) {
-            current += '"';
-          } else {
-            inDouble = !inDouble;
-          }
-        } else {
-          current += '\\'.repeat(numSlashes);
-          i--;
-        }
-        hasContent = true;
-      } else {
-        current += cmd[++i];
-        hasContent = true;
-      }
-    } else if (ch === "'" && !inDouble) {
-      inSingle = !inSingle;
-      hasContent = true;
-    } else if (ch === '"' && !inSingle) {
-      inDouble = !inDouble;
-      hasContent = true;
-    } else if (ch === ' ' && !inSingle && !inDouble) {
-      if (current.length > 0 || hasContent) {
-        tokens.push(current);
-        current = '';
-        hasContent = false;
-      }
-    } else {
-      current += ch;
-      hasContent = true;
-    }
-  }
-  if (current.length > 0 || hasContent) {
-    tokens.push(current);
-  }
-  return tokens;
-}
+const shellTokenize = require('./shellTokenize');
 
 // --- tiny test harness ---
 
@@ -177,6 +119,21 @@ assertTokens(
   // The guard `i + 1 < cmd.length` fails for trailing \, so it falls through
   // to the default branch and is appended literally.
   ['abc\\'],
+);
+
+// Intentional deviation from full MSVC semantics: consecutive double-quotes
+// ("") inside a quoted region are NOT collapsed into a literal '"'.  PIO's
+// compile_commands.json uses backslash-escaping for quotes, never "", so
+// this rule is unnecessary.  The current behavior treats each " as toggling
+// quote mode, producing an empty token.
+assertTokens(
+  'WIN: consecutive "" inside quoted region (intentional deviation from MSVC ""→" rule)',
+  '"a""b"',
+  true,
+  // Full MSVC would produce ['a"b'], but our tokenizer toggles on each " →
+  // 'a' (close quote) + '' (open+close empty) + 'b' (open quote) all
+  // concatenated into the same token because no space separates them.
+  ['ab'],
 );
 
 // ─── POSIX (IS_WINDOWS = false) ─────────────────────────────────────────────

--- a/src/shellTokenize.test.js
+++ b/src/shellTokenize.test.js
@@ -1,0 +1,280 @@
+/**
+ * Unit tests for shellTokenize.
+ *
+ * Run with:  node src/shellTokenize.test.js
+ *
+ * The function is duplicated here with an `isWindows` parameter so the tests
+ * can exercise both platform branches without patching module-level constants.
+ */
+
+'use strict';
+
+// --- shellTokenize (parameterized copy) ---
+
+function shellTokenize(cmd, isWindows) {
+  const tokens = [];
+  let current = '';
+  let hasContent = false;
+  let inSingle = false;
+  let inDouble = false;
+  for (let i = 0; i < cmd.length; i++) {
+    const ch = cmd[i];
+    if (ch === '\\' && !inSingle && i + 1 < cmd.length) {
+      if (isWindows) {
+        let numSlashes = 0;
+        while (i < cmd.length && cmd[i] === '\\') {
+          numSlashes++;
+          i++;
+        }
+        if (i < cmd.length && cmd[i] === '"') {
+          const literalSlashes = Math.floor(numSlashes / 2);
+          current += '\\'.repeat(literalSlashes);
+          if (numSlashes % 2 === 1) {
+            current += '"';
+          } else {
+            inDouble = !inDouble;
+          }
+        } else {
+          current += '\\'.repeat(numSlashes);
+          i--;
+        }
+        hasContent = true;
+      } else {
+        current += cmd[++i];
+        hasContent = true;
+      }
+    } else if (ch === "'" && !inDouble) {
+      inSingle = !inSingle;
+      hasContent = true;
+    } else if (ch === '"' && !inSingle) {
+      inDouble = !inDouble;
+      hasContent = true;
+    } else if (ch === ' ' && !inSingle && !inDouble) {
+      if (current.length > 0 || hasContent) {
+        tokens.push(current);
+        current = '';
+        hasContent = false;
+      }
+    } else {
+      current += ch;
+      hasContent = true;
+    }
+  }
+  if (current.length > 0 || hasContent) {
+    tokens.push(current);
+  }
+  return tokens;
+}
+
+// --- tiny test harness ---
+
+let passed = 0;
+let failed = 0;
+
+function assertTokens(label, input, isWindows, expected) {
+  const actual = shellTokenize(input, isWindows);
+  const ok = JSON.stringify(actual) === JSON.stringify(expected);
+  if (ok) {
+    passed++;
+  } else {
+    failed++;
+    console.error(`FAIL: ${label}`);
+    console.error(`  input:    ${JSON.stringify(input)}  (isWindows=${isWindows})`);
+    console.error(`  expected: ${JSON.stringify(expected)}`);
+    console.error(`  actual:   ${JSON.stringify(actual)}`);
+  }
+}
+
+// ─── Windows (IS_WINDOWS = true) ────────────────────────────────────────────
+
+assertTokens(
+  'WIN: plain Windows path as single token',
+  'C:\\path\\to\\inc',
+  true,
+  ['C:\\path\\to\\inc'],
+);
+
+assertTokens(
+  'WIN: -I with Windows path',
+  '-IC:\\SDK\\include',
+  true,
+  ['-IC:\\SDK\\include'],
+);
+
+assertTokens(
+  'WIN: multiple args with Windows paths',
+  'gcc -IC:\\SDK\\include -o C:\\out\\a.o -c C:\\src\\main.c',
+  true,
+  ['gcc', '-IC:\\SDK\\include', '-o', 'C:\\out\\a.o', '-c', 'C:\\src\\main.c'],
+);
+
+assertTokens(
+  'WIN: -DFOO=\\"bar baz\\" (each \\" is a literal quote, no quoting toggle)',
+  '-DFOO=\\"bar baz\\"',
+  true,
+  // \" (odd count=1) → literal " without toggling quote mode, so the space
+  // still splits tokens.  This matches MSVC/LLVM behavior.
+  ['-DFOO="bar', 'baz"'],
+);
+
+assertTokens(
+  'WIN: -DFOO=\\\\"bar baz\\\\" (even \\\\ + " toggles quote mode)',
+  '-DFOO=\\\\"bar baz\\\\"',
+  true,
+  // \\\\" → 2 backslashes (even) + toggle quote: -DFOO=\  then quoted bar baz
+  // then \\\\" again closes the quote
+  ['-DFOO=\\bar baz\\'],
+);
+
+assertTokens(
+  'WIN: -DBOARD=\\"Espressif ESP32-S3\\" splits (literal quotes, no quoting)',
+  '-DBOARD=\\"Espressif ESP32-S3\\"',
+  true,
+  ['-DBOARD="Espressif', 'ESP32-S3"'],
+);
+
+assertTokens(
+  'WIN: whole arg double-quoted with spaces',
+  '"-DFOO=bar baz"',
+  true,
+  ['-DFOO=bar baz'],
+);
+
+assertTokens(
+  'WIN: 2 backslashes + quote → 1 backslash, toggle quote (even rule)',
+  'a\\\\"b c"',
+  true,
+  ['a\\b c'],
+);
+
+assertTokens(
+  'WIN: 3 backslashes + quote → 1 backslash + literal quote (odd rule)',
+  'a\\\\\\"b',
+  true,
+  ['a\\"b'],
+);
+
+assertTokens(
+  'WIN: 4 backslashes + quote → 2 backslashes, toggle quote',
+  'a\\\\\\\\"b c"',
+  true,
+  ['a\\\\b c'],
+);
+
+assertTokens(
+  'WIN: trailing backslash in quoted string "C:\\dir\\"',
+  '"C:\\dir\\"',
+  true,
+  // The \" at end is odd-count (1) → literal quote, no toggle → quote stays open.
+  // Everything until end-of-string is inside the quote.
+  ['C:\\dir"'],
+);
+
+assertTokens(
+  'WIN: empty double-quoted token',
+  'a "" b',
+  true,
+  ['a', '', 'b'],
+);
+
+assertTokens(
+  'WIN: empty single-quoted token',
+  "a '' b",
+  true,
+  ['a', '', 'b'],
+);
+
+assertTokens(
+  'WIN: backslashes before non-quote are literal',
+  'C:\\a\\b\\c d',
+  true,
+  ['C:\\a\\b\\c', 'd'],
+);
+
+assertTokens(
+  'WIN: single backslash at end of input (no char follows)',
+  'abc\\',
+  true,
+  // The guard `i + 1 < cmd.length` fails for trailing \, so it falls through
+  // to the default branch and is appended literally.
+  ['abc\\'],
+);
+
+// ─── POSIX (IS_WINDOWS = false) ─────────────────────────────────────────────
+
+assertTokens(
+  'POSIX: backslash-n escape',
+  'a\\nb',
+  false,
+  ['anb'],
+);
+
+assertTokens(
+  'POSIX: backslash-backslash produces single backslash',
+  'a\\\\b',
+  false,
+  ['a\\b'],
+);
+
+assertTokens(
+  'POSIX: backslash-quote produces literal quote',
+  'a\\"b',
+  false,
+  ['a"b'],
+);
+
+assertTokens(
+  'POSIX: backslash-space keeps space in token',
+  'a\\ b c',
+  false,
+  ['a b', 'c'],
+);
+
+assertTokens(
+  'POSIX: double-quoted string with spaces',
+  '"hello world" foo',
+  false,
+  ['hello world', 'foo'],
+);
+
+assertTokens(
+  'POSIX: single-quoted string preserves backslash literally',
+  "'a\\b'",
+  false,
+  ['a\\b'],
+);
+
+assertTokens(
+  'POSIX: empty double-quoted token',
+  'a "" b',
+  false,
+  ['a', '', 'b'],
+);
+
+assertTokens(
+  'POSIX: empty single-quoted token',
+  "a '' b",
+  false,
+  ['a', '', 'b'],
+);
+
+assertTokens(
+  'POSIX: mixed quoting styles',
+  'gcc -DFOO="hello world" -DBAR=\'baz qux\'',
+  false,
+  ['gcc', '-DFOO=hello world', '-DBAR=baz qux'],
+);
+
+assertTokens(
+  'POSIX: trailing backslash (no char follows) preserved',
+  'abc\\',
+  false,
+  ['abc\\'],
+);
+
+// ─── Summary ────────────────────────────────────────────────────────────────
+
+console.log(`\n${passed + failed} tests: ${passed} passed, ${failed} failed`);
+if (failed > 0) {
+  process.exit(1);
+}

--- a/src/shellTokenize.test.js
+++ b/src/shellTokenize.test.js
@@ -87,19 +87,13 @@ function assertTokens(label, input, isWindows, expected) {
 
 // ─── Windows (IS_WINDOWS = true) ────────────────────────────────────────────
 
-assertTokens(
-  'WIN: plain Windows path as single token',
+assertTokens('WIN: plain Windows path as single token', 'C:\\path\\to\\inc', true, [
   'C:\\path\\to\\inc',
-  true,
-  ['C:\\path\\to\\inc'],
-);
+]);
 
-assertTokens(
-  'WIN: -I with Windows path',
+assertTokens('WIN: -I with Windows path', '-IC:\\SDK\\include', true, [
   '-IC:\\SDK\\include',
-  true,
-  ['-IC:\\SDK\\include'],
-);
+]);
 
 assertTokens(
   'WIN: multiple args with Windows paths',
@@ -133,12 +127,9 @@ assertTokens(
   ['-DBOARD="Espressif', 'ESP32-S3"'],
 );
 
-assertTokens(
-  'WIN: whole arg double-quoted with spaces',
-  '"-DFOO=bar baz"',
-  true,
-  ['-DFOO=bar baz'],
-);
+assertTokens('WIN: whole arg double-quoted with spaces', '"-DFOO=bar baz"', true, [
+  '-DFOO=bar baz',
+]);
 
 assertTokens(
   'WIN: 2 backslashes + quote → 1 backslash, toggle quote (even rule)',
@@ -170,26 +161,14 @@ assertTokens(
   ['C:\\dir"'],
 );
 
-assertTokens(
-  'WIN: empty double-quoted token',
-  'a "" b',
-  true,
-  ['a', '', 'b'],
-);
+assertTokens('WIN: empty double-quoted token', 'a "" b', true, ['a', '', 'b']);
 
-assertTokens(
-  'WIN: empty single-quoted token',
-  "a '' b",
-  true,
-  ['a', '', 'b'],
-);
+assertTokens('WIN: empty single-quoted token', "a '' b", true, ['a', '', 'b']);
 
-assertTokens(
-  'WIN: backslashes before non-quote are literal',
-  'C:\\a\\b\\c d',
-  true,
-  ['C:\\a\\b\\c', 'd'],
-);
+assertTokens('WIN: backslashes before non-quote are literal', 'C:\\a\\b\\c d', true, [
+  'C:\\a\\b\\c',
+  'd',
+]);
 
 assertTokens(
   'WIN: single backslash at end of input (no char follows)',
@@ -202,40 +181,23 @@ assertTokens(
 
 // ─── POSIX (IS_WINDOWS = false) ─────────────────────────────────────────────
 
-assertTokens(
-  'POSIX: backslash-n escape',
-  'a\\nb',
-  false,
-  ['anb'],
-);
+assertTokens('POSIX: backslash-n escape', 'a\\nb', false, ['anb']);
 
-assertTokens(
-  'POSIX: backslash-backslash produces single backslash',
-  'a\\\\b',
-  false,
-  ['a\\b'],
-);
+assertTokens('POSIX: backslash-backslash produces single backslash', 'a\\\\b', false, [
+  'a\\b',
+]);
 
-assertTokens(
-  'POSIX: backslash-quote produces literal quote',
-  'a\\"b',
-  false,
-  ['a"b'],
-);
+assertTokens('POSIX: backslash-quote produces literal quote', 'a\\"b', false, ['a"b']);
 
-assertTokens(
-  'POSIX: backslash-space keeps space in token',
-  'a\\ b c',
-  false,
-  ['a b', 'c'],
-);
+assertTokens('POSIX: backslash-space keeps space in token', 'a\\ b c', false, [
+  'a b',
+  'c',
+]);
 
-assertTokens(
-  'POSIX: double-quoted string with spaces',
-  '"hello world" foo',
-  false,
-  ['hello world', 'foo'],
-);
+assertTokens('POSIX: double-quoted string with spaces', '"hello world" foo', false, [
+  'hello world',
+  'foo',
+]);
 
 assertTokens(
   'POSIX: single-quoted string preserves backslash literally',
@@ -244,19 +206,9 @@ assertTokens(
   ['a\\b'],
 );
 
-assertTokens(
-  'POSIX: empty double-quoted token',
-  'a "" b',
-  false,
-  ['a', '', 'b'],
-);
+assertTokens('POSIX: empty double-quoted token', 'a "" b', false, ['a', '', 'b']);
 
-assertTokens(
-  'POSIX: empty single-quoted token',
-  "a '' b",
-  false,
-  ['a', '', 'b'],
-);
+assertTokens('POSIX: empty single-quoted token', "a '' b", false, ['a', '', 'b']);
 
 assertTokens(
   'POSIX: mixed quoting styles',
@@ -265,16 +217,15 @@ assertTokens(
   ['gcc', '-DFOO=hello world', '-DBAR=baz qux'],
 );
 
-assertTokens(
-  'POSIX: trailing backslash (no char follows) preserved',
+assertTokens('POSIX: trailing backslash (no char follows) preserved', 'abc\\', false, [
   'abc\\',
-  false,
-  ['abc\\'],
-);
+]);
 
 // ─── Summary ────────────────────────────────────────────────────────────────
 
-process.stdout.write(`\n${passed + failed} tests: ${passed} passed, ${failed} failed\n`);
+process.stdout.write(
+  `\n${passed + failed} tests: ${passed} passed, ${failed} failed\n`,
+);
 if (failed > 0) {
   process.exit(1);
 }

--- a/src/shellTokenize.test.js
+++ b/src/shellTokenize.test.js
@@ -274,7 +274,7 @@ assertTokens(
 
 // ─── Summary ────────────────────────────────────────────────────────────────
 
-console.log(`\n${passed + failed} tests: ${passed} passed, ${failed} failed`);
+process.stdout.write(`\n${passed + failed} tests: ${passed} passed, ${failed} failed\n`);
 if (failed > 0) {
   process.exit(1);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows path and shell command parsing and handling of quoted/backslash cases
  * Compiler resolution now accepts both executable names and .exe variants
  * Compilation database generation is now triggered via the project observer instead of a background spawn

* **Tests**
  * CI build now runs command-tokenization tests
  * Added unit tests covering Windows and POSIX tokenization edge cases

* **Changelog**
  * Bumped release to 1.3.16
<!-- end of auto-generated comment: release notes by coderabbit.ai -->